### PR TITLE
feat: initial configuration for integrating with polling

### DIFF
--- a/app/src/fragments/Onboarding.js
+++ b/app/src/fragments/Onboarding.js
@@ -86,8 +86,11 @@ export default function FullScreenDialog() {
                   title: 'Terima Kasih!',
                   message:
                     'Notifikasi seputar subscriptionmu akan muncul disini'
+                }).then(() => {
+                  setTimeout(() => {
+                    navigate('/')
+                  }, 500)
                 })
-                navigate('/')
               })
               .catch(err => {
                 console.log(err)

--- a/app/src/fragments/Onboarding.js
+++ b/app/src/fragments/Onboarding.js
@@ -86,11 +86,10 @@ export default function FullScreenDialog() {
                   title: 'Terima Kasih!',
                   message:
                     'Notifikasi seputar subscriptionmu akan muncul disini'
-                }).then(() => {
-                  setTimeout(() => {
-                    navigate('/')
-                  }, 500)
                 })
+                setTimeout(() => {
+                  navigate('/')
+                }, 500)
               })
               .catch(err => {
                 console.log(err)

--- a/app/src/fragments/Shell.js
+++ b/app/src/fragments/Shell.js
@@ -10,6 +10,7 @@ import SimpleIcons from 'simple-icons-react-component'
 
 import { navigate } from '@reach/router'
 import { toCurrency, getPeriod } from 'utils'
+import { addNotification } from 'services/notification'
 import { listSubscription } from 'services/subscription'
 
 const classes = {
@@ -98,6 +99,13 @@ export default class App extends Component {
           this.setState({ totalBill })
         })
         this.setState({ subscriptions: docs })
+        addNotification(docs, function() {
+          if (navigator.serviceWorker.controller) {
+            navigator.serviceWorker.controller.postMessage({
+              type: 'NOTIFICATION'
+            })
+          }
+        })
       })
       .catch(err => {
         throw err

--- a/app/src/services/notification.js
+++ b/app/src/services/notification.js
@@ -33,6 +33,13 @@ function getObjectStore(dbInstance, storeName, mode) {
 }
 
 function createIdbInstance() {
+  if (!window.indexedDB) {
+    console.error(
+      "Your browser doesn't support IndexedDB and we are not implementing how to handle that :))"
+    )
+    return
+  }
+
   const db = indexedDB.open(DB_NAME, DB_VERSION)
 
   db.onsuccess = function(e) {
@@ -42,13 +49,28 @@ function createIdbInstance() {
   db.onerror = function(e) {
     console.error('idb:', e.target.errorCode)
   }
+
+  db.onupgradeneeded = function(e) {
+    e.currentTarget.result.createObjectStore('notifications', {
+      keyPath: 'id',
+      autoIncrement: true
+    })
+  }
 }
 
 export function createNotification({ title, message }) {
-  new Notification(title, {
-    body: message,
-    icon: '/images/icons/icon-384x384.png'
-  })
+  if ('serviceWorker' in navigator) {
+    if (navigator.serviceWorker.controller) {
+      navigator.serviceWorker.getRegistration().then(registration => {
+        registration.showNotification(title, {
+          body: message,
+          icon: '/images/icons/icon-384x384.png'
+        })
+      })
+    }
+  } else {
+    window.alert("Your browser doesn't support serviceWorker")
+  }
 }
 
 if (!idbInstance) createIdbInstance()

--- a/app/src/services/notification.js
+++ b/app/src/services/notification.js
@@ -1,6 +1,54 @@
+import dayjs from 'dayjs'
+
+const DB_NAME = '@nadya:workers'
+const DB_VERSION = 1
+
+let idbInstance
+
+export function addNotification(payload, cb) {
+  const notification = getObjectStore(idbInstance, 'notifications', 'readwrite')
+  const $payload = payload.map(data => {
+    const today = dayjs()
+    const currentDate = dayjs(data.firstBill)
+    const isNextMonth = currentDate.diff(today, 'day')
+
+    return {
+      _id: data._id,
+      title: data.title,
+      cost: data.cost,
+      owner: data.owner,
+      billedAt: dayjs(data.firstBill)
+        .add(isNextMonth < 0 ? 1 : 0, 'month')
+        .valueOf()
+    }
+  })
+  notification.clear()
+  notification.add({ id: 'newest', ...$payload })
+  cb(notification)
+}
+
+function getObjectStore(dbInstance, storeName, mode) {
+  const tx = dbInstance.transaction(storeName, mode)
+  return tx.objectStore(storeName)
+}
+
+function createIdbInstance() {
+  const db = indexedDB.open(DB_NAME, DB_VERSION)
+
+  db.onsuccess = function(e) {
+    idbInstance = this.result
+  }
+
+  db.onerror = function(e) {
+    console.error('idb:', e.target.errorCode)
+  }
+}
+
 export function createNotification({ title, message }) {
   new Notification(title, {
     body: message,
     icon: '/images/icons/icon-384x384.png'
   })
 }
+
+if (!idbInstance) createIdbInstance()

--- a/app/src/sw/template.js
+++ b/app/src/sw/template.js
@@ -117,7 +117,7 @@ function startTimer(queue) {
       clearInterval(timerInstance)
       console.log('Timer expired')
     }
-  }, FOR_TESTING)
+  }, ONE_HOUR)
 }
 
 if (!idbInstance) {

--- a/app/src/sw/template.js
+++ b/app/src/sw/template.js
@@ -42,3 +42,103 @@ if ('function' === typeof importScripts) {
     console.log('Workbox could not be loaded. No Offline support')
   }
 }
+
+const DB_NAME = '@nadya:workers'
+const DB_VERSION = 1
+
+let idbInstance
+
+function getObjectStore(dbInstance, storeName, mode) {
+  const tx = dbInstance.transaction(storeName, mode)
+  return tx.objectStore(storeName)
+}
+
+function createIdbInstance() {
+  const db = indexedDB.open(DB_NAME, DB_VERSION)
+
+  db.onsuccess = function(e) {
+    idbInstance = this.result
+  }
+
+  db.onerror = function(e) {
+    console.error('idb:', e.target.errorCode)
+  }
+
+  db.onupgradeneeded = function(e) {
+    const store = e.currentTarget.result.createObjectStore('notifications', {
+      keyPath: 'id',
+      autoIncrement: true
+    })
+  }
+}
+
+function showNotification(payload) {
+  const title = payload.title || 'Notification title'
+  const body = payload.body || 'Notification body'
+
+  self.registration.showNotification(title, {
+    body: body,
+    icon: 'https://inside.evilfactory.id/images/logo.png',
+    tag: payload._id
+  })
+}
+
+function check(queue) {
+  const today = new Date().getDate()
+
+  if (queue) {
+    for (let index in queue) {
+      if (new Date(queue[index].billedAt).getDate() === today) {
+        showNotification({
+          title: queue[index].title,
+          body: queue[index].cost,
+          index
+        })
+      } else {
+        console.log('not today', queue[index])
+      }
+    }
+  }
+}
+
+function startTimer(queue) {
+  const ONE_MONTH = 720 // 24 (hours) * 30 (day)
+  const ONE_HOUR = 3600000
+
+  let counter = 0
+
+  const timerInstance = setInterval(function() {
+    counter++
+
+    check(queue)
+
+    if (counter >= ONE_MONTH) {
+      clearInterval(timerInstance)
+      console.log('Timer expired')
+    }
+  }, ONE_HOUR)
+}
+
+if (!idbInstance) {
+  createIdbInstance()
+}
+
+self.addEventListener('message', function(e) {
+  const payload = e.data
+
+  if (payload.type === 'NOTIFICATION') {
+    const notificationStore = getObjectStore(
+      idbInstance,
+      'notifications',
+      'readwrite'
+    )
+
+    notificationStore.get('newest').onsuccess = function(e) {
+      const queue = e.target.result
+
+      delete e.target.result.id
+
+      startTimer(e.target.result)
+    }
+  }
+})

--- a/app/src/sw/template.js
+++ b/app/src/sw/template.js
@@ -90,9 +90,9 @@ function check(queue) {
     for (let index in queue) {
       if (new Date(queue[index].billedAt).getDate() === today) {
         showNotification({
+          _id: queue[index]._id,
           title: queue[index].title,
-          body: queue[index].cost,
-          index
+          body: queue[index].cost
         })
       } else {
         console.log('not today', queue[index])
@@ -102,6 +102,7 @@ function check(queue) {
 }
 
 function startTimer(queue) {
+  const FOR_TESTING = 60000
   const ONE_MONTH = 720 // 24 (hours) * 30 (day)
   const ONE_HOUR = 3600000
 
@@ -116,7 +117,7 @@ function startTimer(queue) {
       clearInterval(timerInstance)
       console.log('Timer expired')
     }
-  }, ONE_HOUR)
+  }, FOR_TESTING)
 }
 
 if (!idbInstance) {


### PR DESCRIPTION
In this update I try to integrate the app with our Polling implementation.

## Notable notes

- We try to create polling ability via `setInterval`, tick it every 1h (3600000ms), and clear the interval every 1mo (~720 total counter). The "clear" functionality in case user didn't open the app in 1mo and to prevent battery & memory overhead.
- AFAIK, serviceWorker become idle while "there is no task" after some threshold. Because we are doing some Macrotask (`setInterval`), I assume it the `serviceWorker` will never idle :))
- To prevent showing multiple push notification with same content periodically, we use unique `tag` for it.
- Source of truth of "notification content" was on `indexedDB` with key `@nadya:workers` in object `notification` with "identifier" newest. I am too lazy to create any validation, so instead of checking the whole datas, we just clear the database than add it with newest data :)) Don't hate me.

## ANOTHER NOTABLE NOTES

This technique was testing nicely via [`nadya-sw`](https://glitch.com/~nadya-sw). And yes, THIS IS EXTREMELY EXPERIMENTAL AND NOT TESTED.

## ANOTHER ANOTHER NOTABLE NOTES

Please [read this](https://glitch.com/edit/#!/nadya-sw?path=README.md:1:0).

Thanks for your attention.

This PR should close #47 